### PR TITLE
Script, entrypoint, and workflow/action to build separate translation json files

### DIFF
--- a/.github/workflows/build-itembank-translations.yml
+++ b/.github/workflows/build-itembank-translations.yml
@@ -1,0 +1,92 @@
+
+name: Build itembank translations
+
+# Writes per-task, per-locale JSON to gs://levante-assets-dev/translations/itembank/...
+# (see change_utils/change_check/platform_update/build_itembank_translations.py).
+# Required repo secrets: CROWDIN_TOKEN, CROWDIN_LEVANTE_PID, GOOGLE_APPLICATION_CREDENTIALS_DEV_JSON,
+# LEVANTE_AT_PAT, LEVANTE_AT_BASEID, LEVANTE_AT_STRINGSTABLE, SLACK_WEBHOOK_URL (optional for notify).
+
+on:
+  workflow_dispatch:
+    inputs:
+      tasks:
+        description: 'Tasks — "all" or space-separated slugs (e.g. general math trog)'
+        required: true
+        default: 'all'
+      languages:
+        description: 'Locales — "options-file" (from languageoptions.json on dev) or space-separated codes (e.g. es-AR en-US)'
+        required: true
+        default: 'options-file'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install change_check and dependencies
+        working-directory: change_utils
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Set up GCP credentials
+        run: |
+          echo '${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_DEV_JSON }}' > "$RUNNER_TEMP/gcp-creds.json"
+          echo "GOOGLE_APPLICATION_CREDENTIALS_DEV=$RUNNER_TEMP/gcp-creds.json" >> "$GITHUB_ENV"
+
+      - name: Run build-itembank-translations
+        id: build
+        working-directory: change_utils
+        run: |
+          build-itembank-translations --tasks ${{ github.event.inputs.tasks }} --languages ${{ github.event.inputs.languages }}
+        env:
+          CROWDIN_TOKEN: ${{ secrets.CROWDIN_TOKEN }}
+          CROWDIN_LEVANTE_PID: ${{ secrets.CROWDIN_LEVANTE_PID }}
+          LEVANTE_AT_PAT: ${{ secrets.LEVANTE_AT_PAT }}
+          LEVANTE_AT_BASEID: ${{ secrets.LEVANTE_AT_BASEID }}
+          LEVANTE_AT_STRINGSTABLE: ${{ secrets.LEVANTE_AT_STRINGSTABLE }}
+
+      - name: Notify Slack
+        if: success()
+        run: |
+          ITEMBANK_URL="https://console.cloud.google.com/storage/browser/levante-assets-dev/translations/itembank"
+          PAYLOAD=$(cat <<EOF
+          {
+            "text": "Itembank translation JSON build completed",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Itembank translations uploaded*"
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {"type": "mrkdwn", "text": "*Triggered by:*\n${{ github.actor }}"},
+                  {"type": "mrkdwn", "text": "*Workflow:*\n${{ github.workflow }}"},
+                  {"type": "mrkdwn", "text": "*Tasks:*\n${{ github.event.inputs.tasks }}"},
+                  {"type": "mrkdwn", "text": "*Languages:*\n${{ github.event.inputs.languages }}"},
+                  {"type": "mrkdwn", "text": "*Run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"}
+                ]
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "*Output prefix:* <${ITEMBANK_URL}|levante-assets-dev/translations/itembank/>"
+                }
+              }
+            ]
+          }
+          EOF
+          )
+          curl -s -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/build-itembank-translations.yml
+++ b/.github/workflows/build-itembank-translations.yml
@@ -1,7 +1,7 @@
 
 name: Build itembank translations
 
-# Writes per-task, per-locale JSON to gs://levante-assets-dev/translations/itembank/...
+# Writes per-task, per-locale JSON to gs://levante-assets-draft/translations/itembank/...
 # (see change_utils/change_check/platform_update/build_itembank_translations.py).
 # Required repo secrets: CROWDIN_TOKEN, CROWDIN_LEVANTE_PID, GOOGLE_APPLICATION_CREDENTIALS_DEV_JSON,
 # LEVANTE_AT_PAT, LEVANTE_AT_BASEID, LEVANTE_AT_STRINGSTABLE, SLACK_WEBHOOK_URL (optional for notify).
@@ -56,7 +56,7 @@ jobs:
       - name: Notify Slack
         if: success()
         run: |
-          ITEMBANK_URL="https://console.cloud.google.com/storage/browser/levante-assets-dev/translations/itembank"
+          ITEMBANK_URL="https://console.cloud.google.com/storage/browser/levante-assets-draft/translations/itembank"
           PAYLOAD=$(cat <<EOF
           {
             "text": "Itembank translation JSON build completed",
@@ -82,7 +82,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "*Output prefix:* <${ITEMBANK_URL}|levante-assets-dev/translations/itembank/>"
+                  "text": "*Output prefix:* <${ITEMBANK_URL}|levante-assets-draft/translations/itembank/>"
                 }
               }
             ]

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ dist/**
 *.xlf
 package.nls.*.json
 l10n/
+# Local output from build-itembank-translations --local, etc.
+translations/
 .vercel
 *-key.json
 levante-dashboard-*-key.json

--- a/change_utils/change_check/platform_update/build_itembank_translations.py
+++ b/change_utils/change_check/platform_update/build_itembank_translations.py
@@ -4,7 +4,7 @@ Build per-task, per-language flat JSON maps from Crowdin (approved translations 
 Unless ``--languages`` lists explicit locale codes, reads locale keys from
 ``languageoptions.json`` on the dev assets bucket. Maps them to
 Crowdin language ids (``de-DE`` → ``de`` is the only special case), pulls strings from
-item-bank files using ``change_check.utils.build_task_file_map``, and writes
+the hardcoded task → file id map (:data:`~change_check.utils.ITEMBANK_TASK_FILE_MAP`), and writes
 ``item-bank-translations.json`` for each (task, language) pair under ``gs://levante-assets-dev/``
 by default (override with ``--output-bucket``).
 """
@@ -83,8 +83,8 @@ def resolve_task_file_map(task_map: dict[str, Any], selected_tasks: list[str]) -
 			at_key = _airtable_task_key(name, task_map)
 		except KeyError:
 			raise SystemExit(
-				f"No Crowdin file id in Airtable for task {name!r}. "
-				f"Available taskManual keys: {sorted(task_map.keys())}"
+				f"No file id configured for task {name!r}. "
+				f"Available task slugs: {sorted(task_map.keys())}"
 			)
 		out[at_key] = int(task_map[at_key])
 	return out
@@ -147,8 +147,8 @@ def main() -> None:
 		metavar="TASK",
 		required=True,
 		help=(
-			"'all' or one or more taskManual values from Airtable (see build_task_file_map); "
-			"matching is case-insensitive."
+			"'all' or one or more task slugs (see change_check.utils.ITEMBANK_TASK_FILE_MAP); "
+			"matching is case-insensitive; …-dx suffixes map to the base name."
 		),
 	)
 	p.add_argument(
@@ -209,7 +209,7 @@ def main() -> None:
 				bad.append(t)
 		if bad:
 			p.error(
-				f"Unknown task(s): {bad!r}. Use 'all' or any valid task name from the taskManual field in Airtable: {available}"
+				f"Unknown task(s): {bad!r}. Use 'all' or any configured task slug: {available}"
 			)
 		selected = names
 

--- a/change_utils/change_check/platform_update/build_itembank_translations.py
+++ b/change_utils/change_check/platform_update/build_itembank_translations.py
@@ -1,0 +1,262 @@
+"""
+Build per-task, per-language flat JSON maps from Crowdin (approved translations only).
+
+Unless ``--languages`` lists explicit locale codes, reads locale keys from
+``languageoptions.json`` on the dev assets bucket. Maps them to
+Crowdin language ids (``de-DE`` → ``de`` is the only special case), pulls strings from
+item-bank files using ``change_check.utils.build_task_file_map``, and writes
+``item-bank-translations.json`` for each (task, language) pair under ``gs://levante-assets-dev/``
+by default (override with ``--output-bucket``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from crowdin_api import CrowdinClient
+
+from change_check import config, utils
+
+# Allowed CLI names; Airtable ``taskManual`` is matched case-insensitively if needed (e.g. trog ↔ TROG).
+ITEMBANK_TASK_NAMES = (
+	"general",
+	"hearts-and-flowers",
+	"hostile-attribution",
+	"math",
+	"memory-game",
+	"matrix-reasoning",
+	"same-and-different",
+	"trog",
+	"mental-rotation",
+	"theory-of-mind",
+	"child-survey",
+	"vocab",
+)
+
+NO_APPROVED = "NO APPROVED TRANSLATION"
+
+# Dashboard / languageoptions locale → Crowdin target id (only exception today).
+DASHBOARD_LANG_TO_CROWDIN: dict[str, str] = {
+	"de-DE": "de",
+	"nl-NL": "nl"
+}
+
+DEFAULT_DEV_BUCKET = "levante-assets-dev"
+DEFAULT_LANGUAGEOPTIONS_BLOB = "translations/dashboard-consolidated-flat/languageoptions.json"
+
+
+def object_path(task: str, locale_key: str) -> str:
+	"""Path inside the bucket or under ``--local-root`` (``translations/itembank/...``)."""
+	return f"translations/itembank/{task}/{locale_key}/item-bank-translations.json"
+
+
+def dashboard_locale_to_crowdin(locale_key: str) -> str:
+	return DASHBOARD_LANG_TO_CROWDIN.get(locale_key, locale_key)
+
+
+def load_language_option_keys(raw: Any) -> list[str]:
+	"""Top-level locale keys, or ``.languages`` if present."""
+	if isinstance(raw, dict) and "languages" in raw and isinstance(raw["languages"], dict):
+		raw = raw["languages"]
+	if not isinstance(raw, dict):
+		raise ValueError("languageoptions.json must be a JSON object (optionally with a .languages map).")
+	return sorted(str(k) for k in raw.keys())
+
+
+def fetch_languageoptions_json(*, bucket: str, blob_path: str) -> Any:
+	client = utils.initialize_gcs()
+	b = client.bucket(bucket)
+	data = b.blob(blob_path).download_as_bytes()
+	return json.loads(data.decode("utf-8"))
+
+
+def _airtable_task_key(cli_name: str, task_map: dict) -> str:
+	"""Resolve ``taskManual`` key: exact match, else case-insensitive (e.g. ``trog`` → ``TROG``)."""
+	if cli_name in task_map:
+		return cli_name
+	for k in task_map:
+		if k.lower() == cli_name.lower():
+			return k
+	raise KeyError(cli_name)
+
+
+def resolve_task_file_map(selected_tasks: list[str]) -> dict[str, int]:
+	"""CLI task name → Crowdin ``fileId`` (keys stay canonical CLI names for output paths)."""
+	full = utils.build_task_file_map()
+	out: dict[str, int] = {}
+	for name in selected_tasks:
+		try:
+			at_key = _airtable_task_key(name, full)
+		except KeyError:
+			raise SystemExit(
+				f"No Crowdin file id in Airtable for task {name!r}. "
+				f"Available taskManual keys: {sorted(full.keys())}"
+			)
+		# ``split_itembank_fileId`` is a number in Airtable; pyairtable returns int.
+		out[name] = int(full[at_key])
+	return out
+
+
+def iter_strings_for_file(client: CrowdinClient, file_id: int, *, page_size: int = 500):
+	offset = 0
+	while True:
+		resp = client.source_strings.list_strings(fileId=file_id, limit=page_size, offset=offset)
+		batch = resp.get("data") or []
+		for item in batch:
+			yield item
+		if len(batch) < page_size:
+			break
+		offset += page_size
+
+
+def build_translation_map_for_file_language(
+	client: CrowdinClient,
+	file_id: int,
+	crowdin_lang: str,
+) -> dict[str, str]:
+	"""identifier → approved translation text or ``NO_APPROVED`` placeholder."""
+	out: dict[str, str] = {}
+	for item in iter_strings_for_file(client, file_id):
+		data = item.get("data") or {}
+		ident = data.get("identifier")
+		if ident is None or ident == "":
+			continue
+		sid = int(data["id"])
+		text = utils.get_approved_translation_text(client, sid, crowdin_lang)
+		out[str(ident)] = text if text is not None else NO_APPROVED
+	return out
+
+
+def write_json_local(path: Path, payload: dict[str, str]) -> None:
+	path.parent.mkdir(parents=True, exist_ok=True)
+	path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def upload_json_bucket(
+	bucket_name: str,
+	blob_path: str,
+	payload: dict[str, str],
+) -> None:
+	client = utils.initialize_gcs()
+	bucket = client.bucket(bucket_name)
+	blob = bucket.blob(blob_path)
+	blob.upload_from_string(
+		json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+		content_type="application/json; charset=utf-8",
+	)
+
+
+def main() -> None:
+	p = argparse.ArgumentParser(description=__doc__)
+	p.add_argument(
+		"--tasks",
+		nargs="+",
+		metavar="TASK",
+		required=True,
+		help="'all' or one or more of: " + ", ".join(ITEMBANK_TASK_NAMES),
+	)
+	p.add_argument(
+		"--local",
+		action="store_true",
+		help="Write under ./translations/itembank/... instead of GCS.",
+	)
+	p.add_argument(
+		"--language-options-bucket",
+		default=DEFAULT_DEV_BUCKET,
+		help=f"Bucket containing languageoptions.json (default: {DEFAULT_DEV_BUCKET}).",
+	)
+	p.add_argument(
+		"--language-options-blob",
+		default=DEFAULT_LANGUAGEOPTIONS_BLOB,
+		help="Object path to languageoptions.json (used when --languages is options-file).",
+	)
+	p.add_argument(
+		"--languages",
+		nargs="+",
+		default=["options-file"],
+		metavar="LOCALE",
+		help=(
+			"Default: options-file — load locale list from languageoptions.json. "
+			"Otherwise one or more dashboard locale codes (e.g. es-AR en-US). "
+			"options-file must appear alone if used."
+		),
+	)
+	p.add_argument(
+		"--output-bucket",
+		default=DEFAULT_DEV_BUCKET,
+		help=f"Destination bucket when not --local (default: {DEFAULT_DEV_BUCKET}).",
+	)
+	p.add_argument(
+		"--local-root",
+		type=Path,
+		default=Path("translations"),
+		help="Directory that will contain itembank/... when using --local (default: ./translations).",
+	)
+	args = p.parse_args()
+
+	names = [t.strip() for t in args.tasks]
+	if not names or any(not t for t in names):
+		p.error("--tasks: each value must be non-empty.")
+	if names == ["all"]:
+		selected = list(ITEMBANK_TASK_NAMES)
+	else:
+		bad = [t for t in names if t not in ITEMBANK_TASK_NAMES]
+		if bad:
+			p.error(f"Unknown task(s): {bad}. Expected 'all' or any of {list(ITEMBANK_TASK_NAMES)}")
+		if "all" in names:
+			p.error("Use 'all' alone, not mixed with other task names.")
+		selected = names
+
+	lang_spec = [x.strip() for x in args.languages]
+	if not lang_spec or any(not x for x in lang_spec):
+		p.error("--languages: each value must be non-empty.")
+	if lang_spec == ["options-file"]:
+		print(
+			"Loading language keys from gs://{}/{} ...".format(
+				args.language_options_bucket,
+				args.language_options_blob,
+			)
+		)
+		raw = fetch_languageoptions_json(
+			bucket=args.language_options_bucket,
+			blob_path=args.language_options_blob,
+		)
+		locale_keys = load_language_option_keys(raw)
+		print(
+			f"Locales (from languageoptions): {len(locale_keys)} — "
+			f"{', '.join(locale_keys[:12])}{' …' if len(locale_keys) > 12 else ''}"
+		)
+	else:
+		if "options-file" in lang_spec:
+			p.error("Use '--languages options-file' alone (default), not mixed with other locales.")
+		locale_keys = lang_spec
+		print(f"Locales (explicit): {len(locale_keys)} — {', '.join(locale_keys)}")
+
+	task_files = resolve_task_file_map(selected)
+	print(f"Tasks → fileId: {task_files}")
+
+	client = CrowdinClient(token=config.LEV_CI, project_id=config.LEV_CI_PID)
+
+	for task, file_id in task_files.items():
+		for loc in locale_keys:
+			crowdin_lang = dashboard_locale_to_crowdin(loc)
+			print(f"Building {task} / {loc} (Crowdin {crowdin_lang}) fileId={file_id} …")
+			payload = build_translation_map_for_file_language(client, file_id, crowdin_lang)
+			rel = object_path(task, loc)
+			if args.local:
+				dest = args.local_root / "itembank" / task / loc / "item-bank-translations.json"
+				write_json_local(dest, payload)
+				print(f"   → {dest.resolve()} ({len(payload)} keys)")
+			else:
+				upload_json_bucket(args.output_bucket, rel, payload)
+				print(f"   → gs://{args.output_bucket}/{rel} ({len(payload)} keys)")
+
+	print("Done.")
+
+
+if __name__ == "__main__":
+	main()

--- a/change_utils/change_check/platform_update/build_itembank_translations.py
+++ b/change_utils/change_check/platform_update/build_itembank_translations.py
@@ -2,10 +2,10 @@
 Build per-task, per-language flat JSON maps from Crowdin (approved translations only).
 
 Unless ``--languages`` lists explicit locale codes, reads locale keys from
-``languageoptions.json`` on the dev assets bucket. Maps them to
+``languageoptions.json`` (default: dev assets bucket). Maps them to
 Crowdin language ids (``de-DE`` → ``de`` is the only special case), pulls strings from
 the hardcoded task → file id map (:data:`~change_check.utils.ITEMBANK_TASK_FILE_MAP`), and writes
-``item-bank-translations.json`` for each (task, language) pair under ``gs://levante-assets-dev/``
+``item-bank-translations.json`` for each (task, language) pair under ``gs://levante-assets-draft/``
 by default (override with ``--output-bucket``).
 """
 
@@ -23,14 +23,17 @@ from change_check import config, utils
 
 NO_APPROVED = "NO APPROVED TRANSLATION"
 
-# Dashboard / languageoptions locale → Crowdin target id (only exception today).
+# Dashboard / languageoptions locale → Crowdin target id (de and nl only exceptions).
 DASHBOARD_LANG_TO_CROWDIN: dict[str, str] = {
 	"de-DE": "de",
 	"nl-NL": "nl"
 }
 
-DEFAULT_DEV_BUCKET = "levante-assets-dev"
+# Default bucket for reading languageoptions.json (dev consolidated dashboard assets).
+DEFAULT_LANGUAGEOPTIONS_BUCKET = "levante-assets-dev"
 DEFAULT_LANGUAGEOPTIONS_BLOB = "translations/dashboard-consolidated-flat/languageoptions.json"
+# Default bucket for uploaded itembank JSON (dev GCP project; draft staging bucket).
+DEFAULT_OUTPUT_BUCKET = "levante-assets-draft"
 
 
 def object_path(task: str, locale_key: str) -> str:
@@ -158,8 +161,8 @@ def main() -> None:
 	)
 	p.add_argument(
 		"--language-options-bucket",
-		default=DEFAULT_DEV_BUCKET,
-		help=f"Bucket containing languageoptions.json (default: {DEFAULT_DEV_BUCKET}).",
+		default=DEFAULT_LANGUAGEOPTIONS_BUCKET,
+		help=f"Bucket containing languageoptions.json (default: {DEFAULT_LANGUAGEOPTIONS_BUCKET}).",
 	)
 	p.add_argument(
 		"--language-options-blob",
@@ -179,8 +182,8 @@ def main() -> None:
 	)
 	p.add_argument(
 		"--output-bucket",
-		default=DEFAULT_DEV_BUCKET,
-		help=f"Destination bucket when not --local (default: {DEFAULT_DEV_BUCKET}).",
+		default=DEFAULT_OUTPUT_BUCKET,
+		help=f"Destination bucket when not --local (default: {DEFAULT_OUTPUT_BUCKET}).",
 	)
 	p.add_argument(
 		"--local-root",

--- a/change_utils/change_check/platform_update/build_itembank_translations.py
+++ b/change_utils/change_check/platform_update/build_itembank_translations.py
@@ -21,22 +21,6 @@ from crowdin_api import CrowdinClient
 
 from change_check import config, utils
 
-# Allowed CLI names; Airtable ``taskManual`` is matched case-insensitively if needed (e.g. trog ↔ TROG).
-ITEMBANK_TASK_NAMES = (
-	"general",
-	"hearts-and-flowers",
-	"hostile-attribution",
-	"math",
-	"memory-game",
-	"matrix-reasoning",
-	"same-and-different",
-	"trog",
-	"mental-rotation",
-	"theory-of-mind",
-	"child-survey",
-	"vocab",
-)
-
 NO_APPROVED = "NO APPROVED TRANSLATION"
 
 # Dashboard / languageoptions locale → Crowdin target id (only exception today).
@@ -75,29 +59,34 @@ def fetch_languageoptions_json(*, bucket: str, blob_path: str) -> Any:
 
 
 def _airtable_task_key(cli_name: str, task_map: dict) -> str:
-	"""Resolve ``taskManual`` key: exact match, else case-insensitive (e.g. ``trog`` → ``TROG``)."""
+	"""Resolve ``taskManual`` key: exact match, else case-insensitive; ``…-dx`` suffixes match the base name."""
 	if cli_name in task_map:
 		return cli_name
 	for k in task_map:
 		if k.lower() == cli_name.lower():
 			return k
+	norm = utils.normalize_task_manual_key(cli_name)
+	if norm and norm != cli_name:
+		if norm in task_map:
+			return norm
+		for k in task_map:
+			if k.lower() == norm.lower():
+				return k
 	raise KeyError(cli_name)
 
 
-def resolve_task_file_map(selected_tasks: list[str]) -> dict[str, int]:
-	"""CLI task name → Crowdin ``fileId`` (keys stay canonical CLI names for output paths)."""
-	full = utils.build_task_file_map()
+def resolve_task_file_map(task_map: dict[str, Any], selected_tasks: list[str]) -> dict[str, int]:
+	"""CLI task token → Crowdin ``fileId`` (dict keys are canonical task slugs from ``normalize_task_manual_key``)."""
 	out: dict[str, int] = {}
 	for name in selected_tasks:
 		try:
-			at_key = _airtable_task_key(name, full)
+			at_key = _airtable_task_key(name, task_map)
 		except KeyError:
 			raise SystemExit(
 				f"No Crowdin file id in Airtable for task {name!r}. "
-				f"Available taskManual keys: {sorted(full.keys())}"
+				f"Available taskManual keys: {sorted(task_map.keys())}"
 			)
-		# ``split_itembank_fileId`` is a number in Airtable; pyairtable returns int.
-		out[name] = int(full[at_key])
+		out[at_key] = int(task_map[at_key])
 	return out
 
 
@@ -157,7 +146,10 @@ def main() -> None:
 		nargs="+",
 		metavar="TASK",
 		required=True,
-		help="'all' or one or more of: " + ", ".join(ITEMBANK_TASK_NAMES),
+		help=(
+			"'all' or one or more taskManual values from Airtable (see build_task_file_map); "
+			"matching is case-insensitive."
+		),
 	)
 	p.add_argument(
 		"--local",
@@ -198,17 +190,27 @@ def main() -> None:
 	)
 	args = p.parse_args()
 
+	task_map = utils.build_task_file_map()
+	available = sorted(task_map.keys())
+
 	names = [t.strip() for t in args.tasks]
 	if not names or any(not t for t in names):
 		p.error("--tasks: each value must be non-empty.")
 	if names == ["all"]:
-		selected = list(ITEMBANK_TASK_NAMES)
+		selected = list(available)
 	else:
-		bad = [t for t in names if t not in ITEMBANK_TASK_NAMES]
-		if bad:
-			p.error(f"Unknown task(s): {bad}. Expected 'all' or any of {list(ITEMBANK_TASK_NAMES)}")
 		if "all" in names:
 			p.error("Use 'all' alone, not mixed with other task names.")
+		bad: list[str] = []
+		for t in names:
+			try:
+				_airtable_task_key(t, task_map)
+			except KeyError:
+				bad.append(t)
+		if bad:
+			p.error(
+				f"Unknown task(s): {bad!r}. Use 'all' or any valid task name from the taskManual field in Airtable: {available}"
+			)
 		selected = names
 
 	lang_spec = [x.strip() for x in args.languages]
@@ -236,7 +238,7 @@ def main() -> None:
 		locale_keys = lang_spec
 		print(f"Locales (explicit): {len(locale_keys)} — {', '.join(locale_keys)}")
 
-	task_files = resolve_task_file_map(selected)
+	task_files = resolve_task_file_map(task_map, selected)
 	print(f"Tasks → fileId: {task_files}")
 
 	client = CrowdinClient(token=config.LEV_CI, project_id=config.LEV_CI_PID)

--- a/change_utils/change_check/platform_update/update_survey.py
+++ b/change_utils/change_check/platform_update/update_survey.py
@@ -11,20 +11,15 @@ import warnings
 from flatten_json import flatten, unflatten_list
 from change_check import utils
 from change_check import config
-#pulls prod deployed surveys to determine structure.
-urlMap={
-	"caregiver-child":"https://storage.googleapis.com/levante-assets-prod/surveys/parent_survey_child.json",
-	"caregiver-family":"https://storage.googleapis.com/levante-assets-prod/surveys/parent_survey_family.json",
-	"teacher-general":"https://storage.googleapis.com/levante-assets-prod/surveys/teacher_survey_general.json",
-	"teacher-classroom":"https://storage.googleapis.com/levante-assets-prod/surveys/teacher_survey_classroom.json"
-	}
 
-fileMap= {
-	"caregiver-child":776,
-	"caregiver-family":778,
-	"teacher-general":774,
-	"teacher-classroom":782,
+# Prod GCS SurveyJS JSON URLs (same keys as utils.SURVEY_CROWDIN_FILE_MAP). Kept here until survey tooling is reorganized.
+SURVEY_PROD_JSON_URL_MAP = {
+	"caregiver-child": "https://storage.googleapis.com/levante-assets-prod/surveys/parent_survey_child.json",
+	"caregiver-family": "https://storage.googleapis.com/levante-assets-prod/surveys/parent_survey_family.json",
+	"teacher-general": "https://storage.googleapis.com/levante-assets-prod/surveys/teacher_survey_general.json",
+	"teacher-classroom": "https://storage.googleapis.com/levante-assets-prod/surveys/teacher_survey_classroom.json",
 }
+
 
 def main():
 	CLI=argparse.ArgumentParser()
@@ -47,7 +42,7 @@ def main():
 	project=levanteMain.projects.get_project(projectId=config.LEV_CI_PID)
 	allLangs=project["data"]["targetLanguageIds"]
 	print(allLangs)
-	validSurveys=["caregiver-child","caregiver-family","teacher-general","teacher-classroom"]
+	validSurveys = list(utils.SURVEY_CROWDIN_FILE_MAP.keys())
 	langs=args.whitelist
 	surveys=args.types
 	#fix this error to make more informative
@@ -61,20 +56,20 @@ def main():
 	if surveys==["all"] or set(surveys).issubset(validSurveys):
 		print("Building new versions of all adult surveys...")
 		if surveys==["all"]:
-			surveys=[*fileMap]
+			surveys=[*utils.SURVEY_CROWDIN_FILE_MAP]
 	else:
 		raise ValueError(surveyErr)
 	if langs == ["approved"]:
 		approvalTracker={}
 		for s in surveys:
-			approvalTracker[fileMap[s]]=[]
-		fileIds=list(fileMap.values())
-		fileCodes=[*fileMap]
+			approvalTracker[utils.SURVEY_CROWDIN_FILE_MAP[s]]=[]
+		fileIds=list(utils.SURVEY_CROWDIN_FILE_MAP.values())
+		fileCodes=[*utils.SURVEY_CROWDIN_FILE_MAP]
 		for s in surveys:
-			approvalRate=levanteMain.translation_status.get_file_progress(fileId=fileMap[s])
+			approvalRate=levanteMain.translation_status.get_file_progress(fileId=utils.SURVEY_CROWDIN_FILE_MAP[s])
 			for item in approvalRate["data"]:
 				if item["data"]["approvalProgress"]==100:
-					approvalTracker[fileMap[s]].append(item["data"]["languageId"])
+					approvalTracker[utils.SURVEY_CROWDIN_FILE_MAP[s]].append(item["data"]["languageId"])
 
 		#	for f in approvalRate["data"]:
 		#		print(f["data"]["fileId"], lang, f["data"]["approvalProgress"],"\n_________________________")
@@ -93,11 +88,11 @@ def main():
 				updateSurvey(f,approvalTracker[f],scode,"approved")
 	else:
 		for s in surveys:
-			updateSurvey(fileMap[s],langs,s,'latest')
+			updateSurvey(utils.SURVEY_CROWDIN_FILE_MAP[s],langs,s,'latest')
 
 #loads a survey in flattened format
 def loadFlatSurvey(fkey):
-	response=requests.get(urlMap[fkey])
+	response=requests.get(SURVEY_PROD_JSON_URL_MAP[fkey])
 	data = response.json()#json.load(response.json(), object_pairs_hook=OrderedDict)
 	flatData=utils.flatten_custom(data)
 	return flatData

--- a/change_utils/change_check/source_update/update_source_strings.py
+++ b/change_utils/change_check/source_update/update_source_strings.py
@@ -32,27 +32,6 @@ def main():
 		exit()
 
 
-def buildTaskFileMap():
-	"""Build a map of taskManual to split_itembank_fileid from source string airtable."""
-	airtableLevante = Api(config.LEV_AT_PAT)
-	ss_table = airtableLevante.table(config.LEV_AT_BASE, config.LEV_AT_SSTABLE)
-	
-	taskFileMap = {}
-	
-	for record in ss_table.all():
-		fields = record.get("fields", {})
-		taskManual = fields.get("taskManual")
-		splitFileId = fields.get("split_itembank_fileid")
-		
-		# Only add if both values exist and taskManual is not empty
-		if taskManual and splitFileId:
-			# If taskManual already exists, keep the first one (or we could validate they're the same)
-			if taskManual not in taskFileMap:
-				taskFileMap[taskManual] = splitFileId
-	
-	return taskFileMap
-
-
 def updateSourceStringWithTranslations(levanteMain, stringId, newText, pilot, rowId=None, diffTable=None):
 	"""
 	Update a source string in Crowdin and manage its translations based on pilot status.
@@ -211,7 +190,7 @@ def updateTasks(pilot):
 	
 	# Build task file map
 	print("Building task file map from source string airtable...")
-	taskFileMap = buildTaskFileMap()
+	taskFileMap = utils.build_task_file_map()
 	print(f"Found {len(taskFileMap)} unique taskManual to fileId mappings")
 	
 	# Get rows from AT_IB_DIFFTABLE where updated is false or empty

--- a/change_utils/change_check/source_update/update_source_strings.py
+++ b/change_utils/change_check/source_update/update_source_strings.py
@@ -276,15 +276,16 @@ def updateTasks(pilot):
 		ssFields = ssRecord.get("fields", {})
 		taskManual = ssFields.get("taskManual")
 		
-		if not taskManual:
-			print(f"❌ Source string record for {atAudiokey} has no taskManual")
+		task_key = utils.normalize_task_manual_key(taskManual)
+		if not task_key:
+			print(f"❌ Source string record for {atAudiokey} has no usable taskManual")
 			continue
 		
 		# Find fileId in taskFileMap
-		fileId = taskFileMap.get(taskManual)
+		fileId = taskFileMap.get(task_key)
 		
 		if not fileId:
-			print(f"❌ Could not find fileId for taskManual: {taskManual}")
+			print(f"❌ Could not find fileId for taskManual: {taskManual} (key: {task_key})")
 			continue
 		
 		# Get the source string text from at_string

--- a/change_utils/change_check/source_update/update_source_strings.py
+++ b/change_utils/change_check/source_update/update_source_strings.py
@@ -191,7 +191,7 @@ def updateTasks(pilot):
 	# Build task file map
 	print("Building task file map from source string airtable...")
 	taskFileMap = utils.build_task_file_map()
-	print(f"Found {len(taskFileMap)} unique taskManual to fileId mappings")
+	print(f"Using {len(taskFileMap)} task → fileId mappings (ITEMBANK_TASK_FILE_MAP)")
 	
 	# Get rows from AT_IB_DIFFTABLE where updated is false or empty
 	translationTracker = Api(config.AT_TRACKER)

--- a/change_utils/change_check/transition_tools/crowdin_airtable_sync.py
+++ b/change_utils/change_check/transition_tools/crowdin_airtable_sync.py
@@ -3,6 +3,9 @@ import os
 import urllib.request
 import xml.etree.ElementTree as et
 from pyairtable import Api, formulas
+
+from change_check import utils
+
 import config
 
 
@@ -15,17 +18,11 @@ def crowdinCurrent():
 
 def crowdinCurrentSplit():
 	levanteMain=CrowdinClient(token=config.LEV_CI, project_id=config.LEV_CI_PID)
-	api = Api(config.LEV_AT_PAT)
-	table=api.table(config.LEV_AT_BASE,config.LEV_AT_SSTABLE)
-	records=table.all(fields=["audio_file","split_itembank_fileId"])
-	fileIds=[]
-	for record in records:
-		fileIds.append(record['fields']["split_itembank_fileId"])
-	fileIds=list(set(fileIds))
+	fileIds=sorted(set(utils.ITEMBANK_TASK_FILE_MAP.values()))
+	os.makedirs("sync_tmp/", exist_ok=True)
 	for f in fileIds:
 		fileurl=levanteMain.translations.export_project_translation("en-US",fileId=f,format="xliff",skipUntranslatedStrings=False,exportApprovedOnly=False)["data"]["url"]
-	os.makedirs("sync_tmp/", exist_ok=True)
-	urllib.request.urlretrieve(fileurl, "sync_tmp/en-US-source-"+str(f)+".xliff")
+		urllib.request.urlretrieve(fileurl, f"sync_tmp/en-US-source-{f}.xliff")
 	return fileIds
 
 def getItembankItems():
@@ -63,7 +60,6 @@ def syncAirtable_split():
 	levanteMain=CrowdinClient(token=config.LEV_CI, project_id=config.LEV_CI_PID)
 	api = Api(config.LEV_AT_PAT)
 	table=api.table(config.LEV_AT_BASE,config.LEV_AT_SSTABLE)
-	records=table.all(fields=["audio_file","split_itembank_fileId","split_stringId","source_string_of_truth"])
 	for item in itembank:
 		crowdin_stringID = int(item.attrib["id"])
 		resname=item.attrib["resname"]

--- a/change_utils/change_check/transition_tools/debug_crowdin_identifiers.py
+++ b/change_utils/change_check/transition_tools/debug_crowdin_identifiers.py
@@ -108,14 +108,14 @@ def main():
 	parser.add_argument(
 		"--file-id",
 		type=int,
-		default=782,
-		help="Crowdin fileId to inspect (default: 782)",
+		default=utils.SURVEY_CROWDIN_FILE_MAP["teacher-classroom"],
+		help="Crowdin fileId to inspect (default: teacher-classroom from utils.SURVEY_CROWDIN_FILE_MAP)",
 	)
 	parser.add_argument(
 		"--from-prod",
 		nargs="+",
 		help=(
-			"Optional survey keys (as in update_survey.urlMap) whose prod JSON flattened keys "
+			"Optional survey keys (update_survey.SURVEY_PROD_JSON_URL_MAP) whose prod JSON flattened keys "
 			"will be used as additional identifiers to debug."
 		),
 	)
@@ -134,11 +134,11 @@ def main():
 	# Optionally extend with flattened keys from prod JSON for given surveys
 	if args.from_prod:
 		for survey_key in args.from_prod:
-			if survey_key not in update_survey.urlMap:
-				print(f"⚠️  Skipping unknown survey key '{survey_key}' (not in update_survey.urlMap).")
+			if survey_key not in update_survey.SURVEY_PROD_JSON_URL_MAP:
+				print(f"⚠️  Skipping unknown survey key '{survey_key}' (not in update_survey.SURVEY_PROD_JSON_URL_MAP).")
 				continue
 			print(f"Fetching and flattening prod JSON for survey '{survey_key}'...")
-			url = update_survey.urlMap[survey_key]
+			url = update_survey.SURVEY_PROD_JSON_URL_MAP[survey_key]
 			resp = requests.get(url)
 			resp.raise_for_status()
 			data = resp.json()

--- a/change_utils/change_check/transition_tools/get_split_stringIds.py
+++ b/change_utils/change_check/transition_tools/get_split_stringIds.py
@@ -1,8 +1,6 @@
 from crowdin_api import CrowdinClient
-from crowdin_api.sorting import Sorting, SortingOrder, SortingRule
-from crowdin_api.api_resources.string_translations.enums import ListStringTranslationsOrderBy
-from pyairtable import Api, formulas
-from change_check import config
+from pyairtable import Api
+from change_check import config, utils
 import json
 
 
@@ -11,13 +9,7 @@ def main():
 	levanteMain=CrowdinClient(token=config.LEV_CI, project_id=config.LEV_CI_PID)
 	api = Api(config.LEV_AT_PAT)
 	stringtable=api.table(config.LEV_AT_BASE,config.LEV_AT_SSTABLE)
-	translationTracker=Api(config.AT_TRACKER)
-	stringIds=[]
-	records=stringtable.all(fields=["audio_file","split_itembank_fileId"], formula="{split_itembank_fileId} != BLANK()")
-	fileIds=[]
-	for record in records:
-		fileIds.append(record['fields']["split_itembank_fileId"])
-	fileIds=list(set(fileIds))
+	fileIds=sorted(set(utils.ITEMBANK_TASK_FILE_MAP.values()))
 	taskDict={}
 	for f in fileIds:
 		source_strings=levanteMain.source_strings.list_strings(
@@ -30,11 +22,19 @@ def main():
 	with open("newStringIds.json", "w",encoding="utf8") as outfile:
 		json.dump(taskDict, outfile, indent=4, default=str)
 	##start here if successfuly wrote to file
+	records=stringtable.all(
+		fields=["audio_file", "taskManual"],
+		formula="AND({audio_file} != BLANK(), {taskManual} != BLANK())",
+	)
 	for record in records:
-		myfile=record["fields"]["split_itembank_fileId"]
+		fields = record.get("fields", {})
+		task_key = utils.normalize_task_manual_key(fields.get("taskManual"))
+		myfile = utils.ITEMBANK_TASK_FILE_MAP.get(task_key) if task_key else None
+		if myfile is None:
+			continue
 		rowid=record["id"]
 		for item in taskDict[myfile]:
-			if record["fields"]["audio_file"]==item["identifier"]:
+			if fields.get("audio_file")==item["identifier"]:
 				stringtable.update(rowid,{"split_stringId":item["id"]})	
 				break
 if __name__ == "__main__":

--- a/change_utils/change_check/utils.py
+++ b/change_utils/change_check/utils.py
@@ -4,10 +4,34 @@ from crowdin_api import CrowdinClient
 from crowdin_api.sorting import Sorting, SortingOrder, SortingRule
 from crowdin_api.api_resources.string_translations.enums import ListStringTranslationsOrderBy
 from flatten_json import flatten, unflatten_list
-from pyairtable import Api
 from change_check import config
 import warnings
 from google.cloud import storage
+
+
+# Crowdin split itembank file id per task slug (source of truth; not read from Airtable).
+ITEMBANK_TASK_FILE_MAP: Dict[str, int] = {
+	"child-survey": 750,
+	"general": 772,
+	"hearts-and-flowers": 754,
+	"hostile-attribution": 760,
+	"math": 766,
+	"matrix-reasoning": 770,
+	"memory": 756,
+	"mental-rotation": 768,
+	"same-different-selection": 758,
+	"theory-of-mind": 762,
+	"trog": 764,
+	"vocab": 752,
+}
+
+# Adult survey Crowdin file ids (survey slug → file id).
+SURVEY_CROWDIN_FILE_MAP: Dict[str, int] = {
+	"caregiver-child": 776,
+	"caregiver-family": 778,
+	"teacher-general": 774,
+	"teacher-classroom": 782,
+}
 
 
 def normalize_task_manual_key(task_manual: Any) -> Optional[str]:
@@ -24,32 +48,14 @@ def normalize_task_manual_key(task_manual: Any) -> Optional[str]:
 	if s.upper() == "DELETE":
 		return None
 	if s.lower().endswith("-dx"):
-		s = s[:-4]
+		s = s[: -len("-dx")]
 	s = s.lower()
 	return s if s else None
 
 
 def build_task_file_map() -> Dict[str, Any]:
-	"""
-	Map Airtable ``taskManual`` → Crowdin split itembank file id from the source-strings table
-	(``split_itembank_fileId``). Rows whose ``taskManual`` is ``DELETE`` (case-insensitive) are skipped.
-	Keys use :func:`normalize_task_manual_key` (``…-dx`` stripped, then lowercased).
-	"""
-	airtable_levante = Api(config.LEV_AT_PAT)
-	ss_table = airtable_levante.table(config.LEV_AT_BASE, config.LEV_AT_SSTABLE)
-	task_file_map: Dict[str, Any] = {}
-	for record in ss_table.all():
-		fields = record.get("fields", {})
-		task_manual = fields.get("taskManual")
-		split_file_id = fields.get("split_itembank_fileId")
-		if not task_manual or not split_file_id:
-			continue
-		key = normalize_task_manual_key(task_manual)
-		if not key:
-			continue
-		if key not in task_file_map:
-			task_file_map[key] = split_file_id
-	return task_file_map
+	"""Return the hardcoded task slug → Crowdin split itembank file id map (:data:`ITEMBANK_TASK_FILE_MAP`)."""
+	return dict(ITEMBANK_TASK_FILE_MAP)
 
 
 def getSourceString(stringId):

--- a/change_utils/change_check/utils.py
+++ b/change_utils/change_check/utils.py
@@ -1,15 +1,63 @@
+from typing import Any, Dict, Optional
+
 from crowdin_api import CrowdinClient
 from crowdin_api.sorting import Sorting, SortingOrder, SortingRule
 from crowdin_api.api_resources.string_translations.enums import ListStringTranslationsOrderBy
 from flatten_json import flatten, unflatten_list
+from pyairtable import Api
 from change_check import config
 import warnings
 from google.cloud import storage
+
+
+def build_task_file_map() -> Dict[str, Any]:
+	"""
+	Map Airtable ``taskManual`` → Crowdin split itembank file id from the source-strings table
+	(``split_itembank_fileId``).
+	"""
+	airtable_levante = Api(config.LEV_AT_PAT)
+	ss_table = airtable_levante.table(config.LEV_AT_BASE, config.LEV_AT_SSTABLE)
+	task_file_map: Dict[str, Any] = {}
+	for record in ss_table.all():
+		fields = record.get("fields", {})
+		task_manual = fields.get("taskManual")
+		split_file_id = fields.get("split_itembank_fileId")
+		if task_manual and split_file_id:
+			if task_manual not in task_file_map:
+				task_file_map[task_manual] = split_file_id
+	return task_file_map
+
 
 def getSourceString(stringId):
 	levanteMain=CrowdinClient(token=config.LEV_CI, project_id=config.LEV_CI_PID)
 	source_string=levanteMain.source_strings.get_string(stringId=stringId)
 	return source_string["data"]
+
+def get_approved_translation_text(
+	client: CrowdinClient,
+	string_id: int,
+	language_id: str,
+) -> Optional[str]:
+	"""Return text of an **approved** translation for ``language_id``, or ``None`` if none."""
+	sorting = Sorting([SortingRule(ListStringTranslationsOrderBy.CREATED_AT, SortingOrder.DESC)])
+	try:
+		translation = client.string_translations.list_string_translations(
+			stringId=string_id,
+			languageId=language_id,
+			orderBy=sorting,
+		)
+		for t in translation.get("data") or []:
+			approval = client.string_translations.list_translation_approvals(
+				orderBy=sorting,
+				translationId=t["data"]["id"],
+				limit=1,
+			)
+			if len(approval.get("data") or []) > 0:
+				return t["data"]["text"]
+	except Exception:
+		return None
+	return None
+
 
 def getTranslation(stringId,fileId,lcode,translationFilter):
 	levanteMain=CrowdinClient(token=config.LEV_CI, project_id=config.LEV_CI_PID)

--- a/change_utils/change_check/utils.py
+++ b/change_utils/change_check/utils.py
@@ -10,10 +10,30 @@ import warnings
 from google.cloud import storage
 
 
+def normalize_task_manual_key(task_manual: Any) -> Optional[str]:
+	"""
+	Canonical task slug: trim, drop ``DELETE`` (case-insensitive), strip a trailing ``-dx`` suffix
+	(case-insensitive), then lowercase (e.g. ``TROG`` / ``matrix-reasoning-dx`` → ``trog`` /
+	``matrix-reasoning``). Returns ``None`` if the value should be ignored.
+	"""
+	if task_manual is None:
+		return None
+	s = str(task_manual).strip()
+	if not s:
+		return None
+	if s.upper() == "DELETE":
+		return None
+	if s.lower().endswith("-dx"):
+		s = s[:-4]
+	s = s.lower()
+	return s if s else None
+
+
 def build_task_file_map() -> Dict[str, Any]:
 	"""
 	Map Airtable ``taskManual`` → Crowdin split itembank file id from the source-strings table
-	(``split_itembank_fileId``).
+	(``split_itembank_fileId``). Rows whose ``taskManual`` is ``DELETE`` (case-insensitive) are skipped.
+	Keys use :func:`normalize_task_manual_key` (``…-dx`` stripped, then lowercased).
 	"""
 	airtable_levante = Api(config.LEV_AT_PAT)
 	ss_table = airtable_levante.table(config.LEV_AT_BASE, config.LEV_AT_SSTABLE)
@@ -22,9 +42,13 @@ def build_task_file_map() -> Dict[str, Any]:
 		fields = record.get("fields", {})
 		task_manual = fields.get("taskManual")
 		split_file_id = fields.get("split_itembank_fileId")
-		if task_manual and split_file_id:
-			if task_manual not in task_file_map:
-				task_file_map[task_manual] = split_file_id
+		if not task_manual or not split_file_id:
+			continue
+		key = normalize_task_manual_key(task_manual)
+		if not key:
+			continue
+		if key not in task_file_map:
+			task_file_map[key] = split_file_id
 	return task_file_map
 
 

--- a/change_utils/setup.py
+++ b/change_utils/setup.py
@@ -10,7 +10,8 @@ setup(
         "python-dotenv>=1.1.0",
         "argparse>=1.4.0",
         "flatten-json>=0.1.14",
-        "requests>=2.32.5"
+        "requests>=2.32.5",
+        "google-cloud-storage>=2.14.0",
     ],
     entry_points={
         "console_scripts": [
@@ -26,7 +27,8 @@ setup(
             # Platform update
             "build-survey=change_check.platform_update.update_survey:main",
             "build-corpus=change_check.platform_update.build_corpus:main",
-            "split-corpus=change_check.platform_update.split_corpus:main"
+            "split-corpus=change_check.platform_update.split_corpus:main",
+            "build-itembank-translations=change_check.platform_update.build_itembank_translations:main",
             #"review-translations=app.platform_update.fetch_translations:main",
             #"update-translations=app.platform_update.fetch_translations:main"
         ]


### PR DESCRIPTION
# Pull Request

## Description
This creates an entrypoint in the change_check package called build-itembank-translations. This can be run locally by installing the change_package and using the `--local` flag (which will write json files to a local folder instead of a bucket). However, it is designed to be run through the `build_itembank_translations.yml` workflow which will:

- Provide a shared record of when translations were updated, and specifically which translations were updated.
- Post this information to Slack so the team is aligned on translation status.

The entrypoint (and workflow) requires specifying `--tasks`, and accepts `all` (pulls a list of tasks from airtable) or a list of tasks (use airtable task names e.g., matrix-reasoning not pattern matching). By default, it pulls all languages in the languageoptions.json file on dev, but also accepts a `--languages` argument for updating specific languages (e.g.., --languages es-CO es-AR updates only Colombian and Argentinian Spanish).

**This should be tethered to audio generation** - i.e., we need this to trigger a separate workflow that generates new audio if necessary (checks crowdin strings from audio file metadata, if there is a mismatch, regenerates).

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)

## Component(s) affected
- [ ] Audio generation (`generate_speech.py`, voice utilities)
- [ ] Web dashboard (sibling repo: `../levante-web-dashboard/`)
- [x ] Levante dashboard deployment (`deploy_levante.py`)
    - This is a replacement for deploy_levante.py which splits translations into separate json files and allows surgical update by language and task via manually triggered gh action. 
- [] Crowdin integration (`utilities/crowdin_to_gcs.py`)
- [ ] Voice export tools (`utilities/export_*.py`)
- [ ] CSV utilities (`utilities/fix_*.py`)
- [ ] Documentation
- [ ] Development workflow / npm scripts

## Testing
- [ ] I have tested my changes locally
- [ ] I have run `npm run test:dry-run-all` successfully
- [ ] I have updated documentation as needed

## Deployment impact
- [ ] No deployment changes needed
- [ ] Requires updating deployment scripts
- [ ] Requires environment variable changes
- [ ] Requires new dependencies

## Checklist
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Additional notes
Add any additional notes for reviewers here.