### PR TITLE
Use regional locale codes nl-NL and de-DE for Dutch/German audio

### DIFF
--- a/utilities/config.py
+++ b/utilities/config.py
@@ -22,9 +22,9 @@ LANGUAGE_CODES = {
   'English': 'en-US', 
   'English (UK)': 'en-GB', 
   'Spanish': 'es-CO', 
-  'German': 'de', 
+  'German': 'de-DE', 
   'French': 'fr-CA', 
-  'Dutch': 'nl',
+  'Dutch': 'nl-NL',
   'German (Switzerland)': 'de-CH',  # NEW
   'Spanish (Argentina)': 'es-AR',  # NEW
   'Portuguese': 'pt-BR',  # NEW
@@ -60,9 +60,9 @@ def get_languages():
             'voice': 'Valeria',
             'voice_id': '22VndfJPBU7AZORAZZTT',
         },
-        'German': {'lang_code': 'de', 'service': 'ElevenLabs', 'voice': 'Julia'},
+        'German': {'lang_code': 'de-DE', 'service': 'ElevenLabs', 'voice': 'Julia'},
         'French': {'lang_code': 'fr-CA', 'service': 'ElevenLabs', 'voice': 'Caroline - Top France - Narrative, warm, sweet'},
-        'Dutch': {'lang_code': 'nl', 'service': 'ElevenLabs', 'voice': 'Emma - Natural conversations in Dutch'},
+        'Dutch': {'lang_code': 'nl-NL', 'service': 'ElevenLabs', 'voice': 'Emma - Natural conversations in Dutch'},
         'German (Switzerland)': {'lang_code': 'de-CH', 'service': 'ElevenLabs', 'voice': 'Heidi factual (Standard German - with Swiss Accent)'},
         # Use an ElevenLabs Spanish voice available in the account (e.g., 'Sophia')
         'Spanish (Argentina)': {


### PR DESCRIPTION
## Summary
- Fix Dutch and German audio generation, which silently produced **nothing** in draft mode because `config.py` mapped them to generic locale codes (`nl`, `de`) while the draft bucket / item-bank CSV expose them under regional columns (`nl-NL`, `de-DE`).
- Set the local fallback `lang_code`s to `nl-NL` and `de-DE`. The GCS config merge preserves these regional codes via the existing `_prefer_fallback_regional_lang_code` rule (the same one that keeps `en-US` over a remote `en`). Voices are unchanged (Hope / Julia).

## Why it was broken
`generate_speech.py --translation-source draft` looks up translations by exact `lang_code`. The runtime draft CSV has columns `nl-NL` / `de-DE`, so `row['nl']` / `row['de']` never matched and every item was skipped with "No translation found for exact locale …".

## Verification (draft validate-only)
- Dutch: `0/965` → **637/965** translated items resolve (remainder genuinely untranslated).
- German: `0` → **965** items (761 need regeneration, 204 up to date).
- Effective runtime: `Dutch -> nl-NL (Hope)`, `German -> de-DE (Julia)`.

## Notes
- Audio now writes to `audio_files/nl-NL/` and `audio_files/de-DE/` (and `audio/nl-NL`, `audio/de-DE` in GCS), consistent with the other regional locales (es-AR, es-CO, en-US, de-CH, pt-BR). Confirm consuming apps expect these paths.
- French (`fr-CA`) is unaffected — there is currently no French column in the draft data.

## Test plan
- [x] `get_languages()` returns `nl-NL` / `de-DE` with voices preserved.
- [x] Draft validate-only resolves translations for both languages.
- [ ] Full generation run uploads to `audio/nl-NL` and `audio/de-DE` as expected.